### PR TITLE
Add Backport Versions

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,11 +1,5 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.3.1
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 2da194710e10e02277cd6b4fb38fb1d1f3ec2fc7
-Directory: 0.X
-
 Tags: 1.4.0, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git

--- a/library/consul
+++ b/library/consul
@@ -1,5 +1,29 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
+Tags: 0.9.4
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 068a08f88d9e3b313022ac5790c7f884b5aae601
+Directory: 0.X
+
+Tags: 1.0.8
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 3095259fe32be886341fb80d72a6d202a4a808e1
+Directory: 0.X
+
+Tags: 1.1.1
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 82e4bf74b3d2fa57172f32fd06a981e97929d59c
+Directory: 0.X
+
+Tags: 1.2.4
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: af95a2ec9c44fea90458ede561984b2366c57887
+Directory: 0.X
+
 Tags: 1.4.0, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git


### PR DESCRIPTION
This is a PR to our fork on the Consul branch that does two things:

- Removes the 1.3.1 version per the request in https://github.com/docker-library/official-images/pull/5071/files#r234081669
- Adds all backport versions and retains the 1.4.0 version with the latest tag intact

In a future update we should be able to remove all these backport versions similar to the procedure in 1.3.1